### PR TITLE
Remove defaulting to relative line numbers

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -16,8 +16,7 @@ let mapleader = ","
 " Security (don't allow auto execute)
 set modelines=0
 
-" Show relative line numbers (and current number)
-set relativenumber
+" Show line numbers
 set number
 
 " Show file stats


### PR DESCRIPTION
Using relative line numbers is confusing for people newly introduced to vim, so we shouldn't default it.